### PR TITLE
Add support for hardwares that may not have the pcm format we want

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Download system deps
         run: sudo apt-get update -y && sudo apt-get install -y libasound2-dev
-      - name: Install or use cached `cargo-msrv`
-        uses: baptiste0928/cargo-install@v2
-        with:
-          crate: cargo-msrv
+      - uses: cargo-bins/cargo-binstall@main
+      - name: Install cargo-msrv
+        run: cargo binstall cargo-msrv -y
       - name: Verify Minimum Rust Version
-        run: cargo-msrv verify
+        run: cargo msrv verify
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dynwave"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Amjad Alsharafi <amjadsharafi10@gmail.com>"]
 description = "Dynamic audio player based on fixed samples stream"
@@ -15,6 +15,6 @@ rust-version = "1.62.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cpal = "0.15"
+cpal = ">=0.15.3"
 ringbuf = { version = "0.3", default-features = false, features = ["alloc"] }
 rubato = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dynwave"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Amjad Alsharafi <amjadsharafi10@gmail.com>"]
 description = "Dynamic audio player based on fixed samples stream"
@@ -9,12 +9,13 @@ license = "MIT"
 repository = "https://github.com/Amjad50/dynwave"
 keywords = ["audio", "wave", "stream"]
 categories = ["audio", "stream"]
-rust-version = "1.62.0"
+rust-version = "1.70.0"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 cpal = ">=0.15.3"
-ringbuf = { version = "0.3", default-features = false, features = ["alloc"] }
-rubato = "0.14"
+ringbuf = { version = "0.4", default-features = false, features = ["alloc"] }
+rubato = "0.16"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,10 @@ use cpal::{
     FromSample, SizedSample,
 };
 use error::{AudioPlayerError, PlayError};
-use ringbuf::{HeapProducer, HeapRb};
+use ringbuf::{
+    traits::{Producer, Split},
+    HeapProd, HeapRb,
+};
 use rubato::{FftFixedInOut, Resampler, Sample};
 
 struct AudioResampler<T: Sample> {
@@ -72,7 +75,7 @@ impl<T: Sample + SizedSample> AudioResampler<T> {
         })
     }
 
-    fn resample_into_producer(&mut self, data: &[T], producer: &mut HeapProducer<T>) {
+    fn resample_into_producer(&mut self, data: &[T], producer: &mut HeapProd<T>) {
         // helper method to split channels into separate vectors
         fn read_frames<T: Copy>(inbuffer: &[T], n_frames: usize, outputs: &mut [Vec<T>]) {
             for output in outputs.iter_mut() {
@@ -219,7 +222,7 @@ impl BufferSize {
 /// # }
 /// ```
 pub struct AudioPlayer<T: Sample> {
-    buffer_producer: HeapProducer<T>,
+    buffer_producer: HeapProd<T>,
     resampler: Option<AudioResampler<T>>,
     output_stream: cpal::Stream,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,11 @@
 //! # }
 //! ```
 pub mod error;
+mod utils;
 
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    SizedSample,
+    FromSample, SizedSample,
 };
 use error::{AudioPlayerError, PlayError};
 use ringbuf::{HeapProducer, HeapRb};
@@ -223,7 +224,22 @@ pub struct AudioPlayer<T: Sample> {
     output_stream: cpal::Stream,
 }
 
-impl<T: Sample + SizedSample> AudioPlayer<T> {
+impl<T: Sample + SizedSample> AudioPlayer<T>
+where
+    // sadly, cpal uses macro to generate those, and there is no auto way
+    // to use the type system to, even though it seems that it makes sense
+    // to have `T : FromSample<W> where W: SizedSample`?
+    i8: FromSample<T>,
+    i16: FromSample<T>,
+    i32: FromSample<T>,
+    i64: FromSample<T>,
+    u8: FromSample<T>,
+    u16: FromSample<T>,
+    u32: FromSample<T>,
+    u64: FromSample<T>,
+    f32: FromSample<T>,
+    f64: FromSample<T>,
+{
     /// Creates a new instance of `AudioPlayer`.
     ///
     /// # Parameters
@@ -276,22 +292,49 @@ impl<T: Sample + SizedSample> AudioPlayer<T> {
             }
         }
 
-        let (output_sample_rate, resampler) = if found_conf {
-            (sample_rate, None)
+        let (output_sample_rate, output_format, resampler) = if found_conf {
+            (sample_rate, T::FORMAT, None)
         } else {
-            let def_conf = output_device.default_output_config()?;
+            // second time, try to find something that is 2 channels, but format and sample range can
+            // be different, match with highest value
+            let mut max_match = 0;
+            let mut matched_conf = None;
+            for c in &conf {
+                let mut curr_match = 0;
+                if c.channels() == 2 {
+                    curr_match += 1;
+                    if c.sample_format() == T::FORMAT {
+                        curr_match += 3;
+                    }
+                    if c.min_sample_rate() <= sample_rate && c.max_sample_rate() >= sample_rate {
+                        curr_match += 2;
+                    }
+                }
+                if curr_match > max_match {
+                    max_match = curr_match;
+                    matched_conf = Some(c);
+                }
+            }
 
-            if def_conf.channels() != 2 || def_conf.sample_format() != T::FORMAT {
+            let used_conf = match matched_conf {
+                Some(conf) => conf
+                    .try_with_sample_rate(sample_rate)
+                    .unwrap_or_else(|| conf.with_max_sample_rate()),
+                None => output_device.default_output_config()?,
+            };
+
+            if used_conf.channels() != 2 {
                 eprintln!("No supported configuration found for audio device, please open an issue in github `Amjad50/dynwave`\n\
                       list of supported configurations: {:#?}", conf);
                 return Err(AudioPlayerError::DualChannelNotSupported);
             }
 
             (
-                def_conf.sample_rate(),
+                used_conf.sample_rate(),
+                used_conf.sample_format(),
                 Some(AudioResampler::new(
                     sample_rate.0 as usize,
-                    def_conf.sample_rate().0 as usize,
+                    used_conf.sample_rate().0 as usize,
                 )?),
             )
         };
@@ -304,16 +347,17 @@ impl<T: Sample + SizedSample> AudioPlayer<T> {
 
         let ring_buffer_len = buffer_size.store_for_samples(output_sample_rate.0 as usize, 2);
         let buffer = HeapRb::new(ring_buffer_len);
-        let (buffer_producer, mut buffer_consumer) = buffer.split();
+        let (buffer_producer, buffer_consumer) = buffer.split();
 
-        let output_data_fn = move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
-            for sample in data {
-                *sample = buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM);
-            }
-        };
+        let output_data_fn = utils::create_output_processor(output_format, buffer_consumer);
 
-        let output_stream =
-            output_device.build_output_stream(&config, output_data_fn, Self::err_fn, None)?;
+        let output_stream = output_device.build_output_stream_raw(
+            &config,
+            output_format,
+            output_data_fn,
+            Self::err_fn,
+            None,
+        )?;
 
         Ok(Self {
             buffer_producer,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use cpal::{Data, FromSample, Sample, SampleFormat, SizedSample};
-use ringbuf::HeapConsumer;
+use ringbuf::{traits::Consumer, HeapCons};
 
 // Type alias for the processing function - matches the required callback signature
 type ProcessingFn = Box<dyn FnMut(&mut Data, &cpal::OutputCallbackInfo) + Send + 'static>;
@@ -7,7 +7,7 @@ type ProcessingFn = Box<dyn FnMut(&mut Data, &cpal::OutputCallbackInfo) + Send +
 // Function to create the appropriate processing function based on format
 pub fn create_output_processor<T>(
     format: SampleFormat,
-    mut buffer_consumer: HeapConsumer<T>,
+    mut buffer_consumer: HeapCons<T>,
 ) -> ProcessingFn
 where
     T: Sample + SizedSample + Send + 'static,
@@ -29,52 +29,52 @@ where
     match format {
         SampleFormat::I8 => Box::new(move |data, _| {
             for sample in data.as_slice_mut::<i8>().expect("Valid format") {
-                *sample = i8::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+                *sample = i8::from_sample(buffer_consumer.try_pop().unwrap_or(T::EQUILIBRIUM));
             }
         }),
         SampleFormat::I16 => Box::new(move |data, _| {
             for sample in data.as_slice_mut::<i16>().expect("Valid format") {
-                *sample = i16::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+                *sample = i16::from_sample(buffer_consumer.try_pop().unwrap_or(T::EQUILIBRIUM));
             }
         }),
         SampleFormat::I32 => Box::new(move |data, _| {
             for sample in data.as_slice_mut::<i32>().expect("Valid format") {
-                *sample = i32::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+                *sample = i32::from_sample(buffer_consumer.try_pop().unwrap_or(T::EQUILIBRIUM));
             }
         }),
         SampleFormat::I64 => Box::new(move |data, _| {
             for sample in data.as_slice_mut::<i64>().expect("Valid format") {
-                *sample = i64::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+                *sample = i64::from_sample(buffer_consumer.try_pop().unwrap_or(T::EQUILIBRIUM));
             }
         }),
         SampleFormat::U8 => Box::new(move |data, _| {
             for sample in data.as_slice_mut::<u8>().expect("Valid format") {
-                *sample = u8::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+                *sample = u8::from_sample(buffer_consumer.try_pop().unwrap_or(T::EQUILIBRIUM));
             }
         }),
         SampleFormat::U16 => Box::new(move |data, _| {
             for sample in data.as_slice_mut::<u16>().expect("Valid format") {
-                *sample = u16::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+                *sample = u16::from_sample(buffer_consumer.try_pop().unwrap_or(T::EQUILIBRIUM));
             }
         }),
         SampleFormat::U32 => Box::new(move |data, _| {
             for sample in data.as_slice_mut::<u32>().expect("Valid format") {
-                *sample = u32::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+                *sample = u32::from_sample(buffer_consumer.try_pop().unwrap_or(T::EQUILIBRIUM));
             }
         }),
         SampleFormat::U64 => Box::new(move |data, _| {
             for sample in data.as_slice_mut::<u64>().expect("Valid format") {
-                *sample = u64::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+                *sample = u64::from_sample(buffer_consumer.try_pop().unwrap_or(T::EQUILIBRIUM));
             }
         }),
         SampleFormat::F32 => Box::new(move |data, _| {
             for sample in data.as_slice_mut::<f32>().expect("Valid format") {
-                *sample = f32::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+                *sample = f32::from_sample(buffer_consumer.try_pop().unwrap_or(T::EQUILIBRIUM));
             }
         }),
         SampleFormat::F64 => Box::new(move |data, _| {
             for sample in data.as_slice_mut::<f64>().expect("Valid format") {
-                *sample = f64::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+                *sample = f64::from_sample(buffer_consumer.try_pop().unwrap_or(T::EQUILIBRIUM));
             }
         }),
         e => panic!("Format {e:?} isn't supported"),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,82 @@
+use cpal::{Data, FromSample, Sample, SampleFormat, SizedSample};
+use ringbuf::HeapConsumer;
+
+// Type alias for the processing function - matches the required callback signature
+type ProcessingFn = Box<dyn FnMut(&mut Data, &cpal::OutputCallbackInfo) + Send + 'static>;
+
+// Function to create the appropriate processing function based on format
+pub fn create_output_processor<T>(
+    format: SampleFormat,
+    mut buffer_consumer: HeapConsumer<T>,
+) -> ProcessingFn
+where
+    T: Sample + SizedSample + Send + 'static,
+
+    // sadly, cpal uses macro to generate those, and there is no auto way
+    // to use the type system to, even though it seems that it makes sense
+    // to have `T : FromSample<W> where W: SizedSample`?
+    i8: FromSample<T>,
+    i16: FromSample<T>,
+    i32: FromSample<T>,
+    i64: FromSample<T>,
+    u8: FromSample<T>,
+    u16: FromSample<T>,
+    u32: FromSample<T>,
+    u64: FromSample<T>,
+    f32: FromSample<T>,
+    f64: FromSample<T>,
+{
+    match format {
+        SampleFormat::I8 => Box::new(move |data, _| {
+            for sample in data.as_slice_mut::<i8>().expect("Valid format") {
+                *sample = i8::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+            }
+        }),
+        SampleFormat::I16 => Box::new(move |data, _| {
+            for sample in data.as_slice_mut::<i16>().expect("Valid format") {
+                *sample = i16::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+            }
+        }),
+        SampleFormat::I32 => Box::new(move |data, _| {
+            for sample in data.as_slice_mut::<i32>().expect("Valid format") {
+                *sample = i32::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+            }
+        }),
+        SampleFormat::I64 => Box::new(move |data, _| {
+            for sample in data.as_slice_mut::<i64>().expect("Valid format") {
+                *sample = i64::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+            }
+        }),
+        SampleFormat::U8 => Box::new(move |data, _| {
+            for sample in data.as_slice_mut::<u8>().expect("Valid format") {
+                *sample = u8::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+            }
+        }),
+        SampleFormat::U16 => Box::new(move |data, _| {
+            for sample in data.as_slice_mut::<u16>().expect("Valid format") {
+                *sample = u16::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+            }
+        }),
+        SampleFormat::U32 => Box::new(move |data, _| {
+            for sample in data.as_slice_mut::<u32>().expect("Valid format") {
+                *sample = u32::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+            }
+        }),
+        SampleFormat::U64 => Box::new(move |data, _| {
+            for sample in data.as_slice_mut::<u64>().expect("Valid format") {
+                *sample = u64::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+            }
+        }),
+        SampleFormat::F32 => Box::new(move |data, _| {
+            for sample in data.as_slice_mut::<f32>().expect("Valid format") {
+                *sample = f32::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+            }
+        }),
+        SampleFormat::F64 => Box::new(move |data, _| {
+            for sample in data.as_slice_mut::<f64>().expect("Valid format") {
+                *sample = f64::from_sample(buffer_consumer.pop().unwrap_or(T::EQUILIBRIUM));
+            }
+        }),
+        e => panic!("Format {e:?} isn't supported"),
+    }
+}


### PR DESCRIPTION
This aims to fix https://github.com/Amjad50/dynwave/issues/2

Where the emulator is requesting PCM F32 format, but the device the user have doesn't support that.

We can get around that by choosing a format the hardware support and then converting each sample to this new format.

If the device has the same format, the `from_sample` should be optimized away to nothing.

Needed to manually update `cpal`, since looks like they don't follow semver correctly, they added a functionality that I need but they updated the PATCH number only